### PR TITLE
Use new setters and fix one local qualifier missing

### DIFF
--- a/i_functions.lua
+++ b/i_functions.lua
@@ -52,6 +52,7 @@ local compare = draw_ta
 		compare = draw_tl
 	end	
 		
+	local_ndraw
 	for k,v in pairs(nodes) do
 		n_draw = minetest.registered_nodes[v.name].drawtype
 			for k2,v2 in ipairs(compare) do 

--- a/init.lua
+++ b/init.lua
@@ -26,29 +26,18 @@
 ----------------------------
 local modname = minetest.get_current_modname()
 local modpath = minetest.get_modpath(modname)
-local add_capes = minetest.setting_getbool("capes_add_to_3darmor")
-local example_cape = minetest.setting_getbool("example_cape")
-local fly_anim = minetest.setting_getbool("fly_anim")
-local fall_anim = minetest.setting_getbool("fall_anim")
-local fall_tv = minetest.setting_getbool("fall_tv") or 100
+local add_capes = minetest.settings:get_bool("capes_add_to_3darmor" ,true)
+local example_cape = minetest.settings:get_bool("example_cape" ,true)
+local fly_anim = minetest.settings:get_bool("fly_anim" ,true)
+local fall_anim = minetest.settings:get_bool("fall_anim" ,true)
+local fall_tv = tonumber(minetest.settings:get("fall_tv" ,true)) or 100
 	  fall_tv = -1*(fall_tv/3.7)                             -- Convert kp/h back to number of -y blocks per 0.05 of a second.
-local swim_anim = minetest.setting_getbool("swim_anim")
-local swim_sneak = minetest.setting_getbool("swim_sneak")
-local climb_anim = minetest.setting_getbool("climb_anim")
-local crouch_anim = minetest.setting_getbool("crouch_anim")
-local crouch_sneak = minetest.setting_getbool("crouch_sneak")
+local swim_anim = minetest.settings:get_bool("swim_anim" ,true)
+local swim_sneak = minetest.settings:get_bool("swim_sneak" ,true)
+local climb_anim = minetest.settings:get_bool("climb_anim" ,true)
+local crouch_anim = minetest.settings:get_bool("crouch_anim" ,true)
+local crouch_sneak = minetest.settings:get_bool("crouch_sneak" ,true)
  
--- catch setting nil, need "if" as boolean 
-if add_capes    == nil then add_capes    = true end 
-if example_cape == nil then example_cape = true end 
-if fly_anim     == nil then fly_anim     = true end 
-if fall_anim    == nil then fall_anim    = true end 
-if swim_anim    == nil then swim_anim    = true end 
-if swim_sneak   == nil then swim_sneak   = true end 
-if climb_anim   == nil then climb_anim   = true end 
-if crouch_anim  == nil then crouch_anim  = true end 
-if crouch_sneak == nil then crouch_sneak = true end 
-
 local d_fall_anim = 0                                        -- Stop fall animation from playing after pressing shift_dwn 
                                                              -- and flying otherwise looks funny flicking to falling.
 -------------------------------------


### PR DESCRIPTION
New settings:get_bool offers a default return value.
So checking for nil value is not more required and there is no log about deprecated calls at server startup.

There was a inconsistent declaration of global variable in i_function:56